### PR TITLE
[Feature Request] Add flag to enable/disable auto-merge logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ To use the "Merge Base Branch into PR" action in your GitHub workflows, follow t
 The action requires the following input:
 
 - `baseBranch` (required): The base branch to compare and merge with the pull request branch.
+- `autoMerge` (optional): A flag to enable or disable the automatic merge of the base branch into the pull request branch. Default is `true`.
+- `descriptionMerged` (optional): Customized the merge commit message.
+- `descriptionReminder` (optional): Customized the reminder message posted on the PR comment if autoMerge is disabled.
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
 
   descriptionReminder:
     required: false
-    description: 'Description of the PR comment if 'autoMerge' is false.'
+    description: 'Description of the PR comment if "autoMerge" is false.'
     default: 'Please merge `${{ github.event.pull_request.base.ref }}` into `${{ github.event.pull_request.head.ref }}`.'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,21 @@ inputs:
     required: true
     description: 'The base branch to compare and merge.'
 
+  autoMerge:
+    required: false
+    description: 'Automatically merge the base branch into the pull request branch if necessary.'
+    default: 'true'
+
+  descriptionMerged:
+    required: false
+    description: 'Description of the merge commit.'
+    default: 'Merge ${{ github.event.pull_request.base.ref }} into ${{ github.event.pull_request.head.ref }}'
+
+  descriptionReminder:
+    required: false
+    description: 'Description of the PR comment if 'autoMerge' is false.'
+    default: 'Please merge `${{ github.event.pull_request.base.ref }}` into `${{ github.event.pull_request.head.ref }}`.'
+
 runs:
   using: 'composite'
   steps:
@@ -28,28 +43,42 @@ runs:
         BASE=$(git merge-base origin/${{ github.event.pull_request.base.ref }} HEAD)
         if [ $BASE = $(git rev-parse origin/${{ github.event.pull_request.base.ref }}) ]; then
           echo "Branches are up to date, skipping merge."
-          echo "::set-output name=mergeRequired::false"
+          echo "mergeRequired=false" >> $GITHUB_OUTPUT
         else
           echo "Branches are not up to date, merge is required."
-          echo "::set-output name=mergeRequired::true"
+          echo "mergeRequired=true" >> $GITHUB_OUTPUT
         fi
 
     - name: Merge base branch into PR branch
       shell: bash
-      if: steps.checkBranches.outputs.mergeRequired == 'true'
+      if: steps.checkBranches.outputs.mergeRequired == 'true' && inputs.autoMerge == 'true'
       run: |
         git merge --no-edit --no-commit origin/${{ github.event.pull_request.base.ref }}
         if [ $? -ne 0 ]; then
           echo "Merge conflict detected. Please resolve conflicts before merging."
           exit 1
         fi
-        git commit -m "Merge ${{ github.event.pull_request.base.ref }} into ${{ github.event.pull_request.head.ref }}"
+        git commit -m "${{ inputs.descriptionMerged }}"
 
     - name: Push changes
       shell: bash
-      if: steps.checkBranches.outputs.mergeRequired == 'true'
+      if: steps.checkBranches.outputs.mergeRequired == 'true' && inputs.autoMerge == 'true'
       run: |
         git push origin ${{ github.event.pull_request.head.ref }}
+
+    - name: Command on PR to remind the PR branch is not up to date
+      if: steps.checkBranches.outputs.mergeRequired == 'true' && inputs.autoMerge == 'false'
+      uses: thollander/actions-comment-pull-request@v3.0.1
+      with:
+        message: |
+          ## This branch is out-of-date with the base branch
+          ${{ inputs.descriptionReminder }}
+        comment-tag: pr-up-to-date
+
+    - name: Block the workflow if the PR branch is not up to date
+      shell: bash
+      if: steps.checkBranches.outputs.mergeRequired == 'true' && inputs.autoMerge == 'false'
+      run: exit 1
 
 branding:
   icon: 'git-pull-request'


### PR DESCRIPTION
# What does this PR do?
In this PR, we add a flag `autoMerge` to configure the PR-Update action.
Once the `autoMerge` flag has been set to `false,` the action will post a comment on PR to remind the user instead of merging the base branch directly.
Also, the user can use `descriptionMerged` and `descriptionMerged` to customize the output message of git commit and PR comment.
By the way, the default value of `auto merge` will be `true`, and it's not a required field.
Adding this flag wrong changes the existing behavior if the user doesn't modify their GitHub action workflow. 

# Why is this PR needed?
It's great to know if a PR branch is up-to-date. 
However, in some cases, auto-merging the base branch without user interaction is too aggressive.
By using `autoMerge` flag, the user can configure the action behavior based on the need.

 